### PR TITLE
fix topN, groupBy query for lodash 4.x

### DIFF
--- a/src/datasource.js
+++ b/src/datasource.js
@@ -474,7 +474,7 @@ function (angular, _, dateMath, moment) {
           the _.assign() callback will get called for every new val
           that we add to the final object.
         */
-        return _.assign(prev, curr, function (pVal, cVal) {
+        return _.assignWith(prev, curr, function (pVal, cVal) {
           if (pVal) {
             pVal.push(cVal);
             return pVal;

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -425,7 +425,7 @@ function (angular, _, dateMath, moment) {
           the _.assign() callback will get called for every new val
           that we add to the final object.
         */
-        return _.assign(prev, curr, function (pVal, cVal) {
+        return _.assignWith(prev, curr, function (pVal, cVal) {
           if (pVal) {
             pVal.push(cVal);
             return pVal;

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -19,7 +19,7 @@
       "large": "img/druid_logo.png"
     },
    "dependencies": {
-     "grafanaVersion": "3.x.x",
+     "grafanaVersion": "4.x.x",
      "plugins": [ ]
     }
   }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -520,7 +520,7 @@ export class DruidQueryCtrl extends QueryCtrl {
 
       if (this.target.shouldOverrideGranularity) {
         if (this.target.customGranularity) {
-          if (!_.contains(this.customGranularity, this.target.customGranularity)) {
+          if (!_.includes(this.customGranularity, this.target.customGranularity)) {
             errs.customGranularity = "Invalid granularity.";
           }
         } else {


### PR DESCRIPTION
lodash v4.0 split _.assign() into assign, assignIn, assignWith, assignInWith methods.
The one with callback has to use -With methods.  See https://lodash.com/docs#assignWith

FYI, convertGroupByData uses _.assign() with callback, too.  Applied the same fix.

Also _.containes was replaced with _.includes.

This is a backward incompatible change.  You might want to create a v4 branch.