### PR TITLE
Remove pretty parameter from the request url for Druid API

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -263,7 +263,7 @@ function (angular, _, dateMath, moment) {
     this._druidQuery = function (query) {
       var options = {
         method: 'POST',
-        url: this.url + '/druid/v2/?pretty',
+        url: this.url + '/druid/v2/',
         data: query
       };
       console.log("Make http request");

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -263,7 +263,7 @@ function (angular, _, dateMath, moment) {
     this._druidQuery = function (query) {
       var options = {
         method: 'POST',
-        url: this.url + '/druid/v2/?pretty',
+        url: this.url + '/druid/v2/',
         data: query
       };
       console.log("Make http request");


### PR DESCRIPTION
The pretty parameter is for pretty printing response data in JSON format. From the aspect of network traffic, I think that it is more efficient to remove this parameter. Please check this pull request.

Thanks.