### PR TITLE
Add node_modules & npm-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log


### PR DESCRIPTION
In order to setup the environment for developing druidplugin, I would like to install the dependencies described in package.json to node_modules directory using the ```npm install``` command. But, I think that node_modules and npm-debug.log don't normally check in to the repository. So, I added these files and directories to gitignore. Please check this pull request.

Thanks.