### PR TITLE
Add grunt-cli to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Grafana plugin for Druid real-time OLAP database",
   "main": "index.js",
   "scripts": {
+    "build": "grunt",
     "test": "echo \\\"Error: no test specified\\\" && exit 1"
   },
   "repository": {
@@ -23,6 +24,7 @@
     "chai": "~3.5.0",
     "grunt": "~0.4.5",
     "grunt-babel": "~6.0.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-copy": "~0.8.2",
     "grunt-contrib-uglify": "~0.11.0",


### PR DESCRIPTION
In order to build using the grunt of specified version in package.json, I added grunt-cli as a dev-dependency. This patch allows you to execute grunt task with ```npm run build``` command.
I'm sorry that I sent many small Pull Requests. Please confirm.

Thanks