### PR TITLE
Add support old browser

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -151,7 +151,7 @@ function (angular, _, dateMath, moment) {
       var filters = target.filters;
       var aggregators = target.aggregators;
       var postAggregators = target.postAggregators;
-      var groupBy = _.map(target.groupBy, (e) => { return templateSrv.replace(e) });
+      var groupBy = _.map(target.groupBy, function(e) { return templateSrv.replace(e) });
       var limitSpec = null;
       var metricNames = getMetricNames(aggregators, postAggregators);
       var intervals = getQueryIntervals(from, to);

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -151,7 +151,7 @@ function (angular, _, dateMath, moment) {
       var filters = target.filters;
       var aggregators = target.aggregators;
       var postAggregators = target.postAggregators;
-      var groupBy = _.map(target.groupBy, (e) => { return templateSrv.replace(e) });
+      var groupBy = _.map(target.groupBy, function(e) { return templateSrv.replace(e) });
       var limitSpec = null;
       var metricNames = getMetricNames(aggregators, postAggregators);
       var intervals = getQueryIntervals(from, to);


### PR DESCRIPTION
Add support old browser (in this case we're using LG SmartTv WebOS Browser) by remove ES6's arrow function
ref: http://html5test.com/s/eff1c83e12699cc0.html