### PR TITLE
Add support to repeat panel with template variable filter.

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -32,9 +32,9 @@ function (angular, _, dateMath, moment) {
     this.supportMetrics = true;
     this.periodGranularity = instanceSettings.jsonData.periodGranularity;
 
-    function replaceTemplateValues(obj, attrList) {
+    function replaceTemplateValues(obj, scopedVars, attrList) {
       var substitutedVals = attrList.map(function (attr) {
-        return templateSrv.replace(obj[attr]);
+        return templateSrv.replace(obj[attr], scopedVars);
       });
       return _.assign(_.clone(obj, true), _.zipObject(attrList, substitutedVals));
     }
@@ -140,7 +140,7 @@ function (angular, _, dateMath, moment) {
                 granularity = {"type": "period", "period": "P1D", "timeZone": dataSource.periodGranularity}
             }
         }
-        return dataSource._doQuery(roundedFrom, to, granularity, target);
+        return dataSource._doQuery(roundedFrom, to, granularity, target, options.scopedVars);
       });
 
       return $q.all(promises).then(function(results) {
@@ -148,7 +148,7 @@ function (angular, _, dateMath, moment) {
       });
     };
 
-    this._doQuery = function (from, to, granularity, target) {
+    this._doQuery = function (from, to, granularity, target, scopedVars) {
 
       function splitCardinalityFields(aggregator) {
         if (aggregator.type === 'cardinality' && typeof aggregator.fieldNames === 'string') {
@@ -178,26 +178,26 @@ function (angular, _, dateMath, moment) {
         var threshold = target.limit;
         var metric = target.druidMetric;
         var dimension = templateSrv.replace(target.dimension);
-        promise = this._topNQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, threshold, metric, dimension)
+        promise = this._topNQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, threshold, metric, dimension, scopedVars)
           .then(function(response) {
             return convertTopNData(response.data, dimension, metric);
           });
       }
       else if (target.queryType === 'groupBy') {
         limitSpec = getLimitSpec(target.limit, target.orderBy);
-        promise = this._groupByQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, groupBy, limitSpec)
+        promise = this._groupByQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, groupBy, limitSpec, scopedVars)
           .then(function(response) {
             return convertGroupByData(response.data, groupBy, metricNames);
           });
       }
       else if (target.queryType === 'select') {
-        promise = this._selectQuery(datasource, intervals, granularity, selectDimensions, selectMetrics, filters, selectThreshold);
+        promise = this._selectQuery(datasource, intervals, granularity, selectDimensions, selectMetrics, filters, selectThreshold, scopedVars);
         return promise.then(function(response) {
           return convertSelectData(response.data);
         });
       }
       else {
-        promise = this._timeSeriesQuery(datasource, intervals, granularity, filters, aggregators, postAggregators)
+        promise = this._timeSeriesQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, scopedVars)
           .then(function(response) {
             return convertTimeSeriesData(response.data, metricNames);
           });
@@ -229,7 +229,7 @@ function (angular, _, dateMath, moment) {
       });
     };
 
-    this._selectQuery = function (datasource, intervals, granularity, dimension, metric, filters, selectThreshold) {
+    this._selectQuery = function (datasource, intervals, granularity, dimension, metric, filters, selectThreshold, scopedVars) {
       var query = {
         "queryType": "select",
         "dataSource": datasource,
@@ -241,13 +241,13 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
     };
 
-    this._timeSeriesQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators) {
+    this._timeSeriesQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators, scopedVars) {
       var query = {
         "queryType": "timeseries",
         "dataSource": datasource,
@@ -258,14 +258,14 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
     };
 
     this._topNQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators,
-    threshold, metric, dimension) {
+    threshold, metric, dimension, scopedVars) {
       var query = {
         "queryType": "topN",
         "dataSource": datasource,
@@ -280,14 +280,14 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
     };
 
     this._groupByQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators,
-    groupBy, limitSpec) {
+    groupBy, limitSpec, scopedVars) {
       var query = {
         "queryType": "groupBy",
         "dataSource": datasource,
@@ -300,7 +300,7 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
@@ -327,10 +327,10 @@ function (angular, _, dateMath, moment) {
       };
     }
 
-    function buildFilterTree(filters) {
+    function buildFilterTree(filters, scopedVars) {
       //Do template variable replacement
       var replacedFilters = filters.map(function (filter) {
-        return filterTemplateExpanders[filter.type](filter);
+        return filterTemplateExpanders[filter.type](filter, scopedVars);
       })
       .map(function (filter) {
         var finalFilter = _.omit(filter, 'negate');

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -32,9 +32,9 @@ function (angular, _, dateMath, moment) {
     this.supportMetrics = true;
     this.periodGranularity = instanceSettings.jsonData.periodGranularity;
 
-    function replaceTemplateValues(obj, attrList) {
+    function replaceTemplateValues(obj, scopedVars, attrList) {
       var substitutedVals = attrList.map(function (attr) {
-        return templateSrv.replace(obj[attr]);
+        return templateSrv.replace(obj[attr], scopedVars);
       });
       return _.assign(_.clone(obj, true), _.zipObject(attrList, substitutedVals));
     }
@@ -140,7 +140,7 @@ function (angular, _, dateMath, moment) {
                 granularity = {"type": "period", "period": "P1D", "timeZone": dataSource.periodGranularity}
             }
         }
-        return dataSource._doQuery(roundedFrom, to, granularity, target);
+        return dataSource._doQuery(roundedFrom, to, granularity, target, options.scopedVars);
       });
 
       return $q.all(promises).then(function(results) {
@@ -148,7 +148,7 @@ function (angular, _, dateMath, moment) {
       });
     };
 
-    this._doQuery = function (from, to, granularity, target) {
+    this._doQuery = function (from, to, granularity, target, scopedVars) {
 
       function splitCardinalityFields(aggregator) {
         if (aggregator.type === 'cardinality' && typeof aggregator.fieldNames === 'string') {
@@ -178,26 +178,26 @@ function (angular, _, dateMath, moment) {
         var threshold = target.limit;
         var metric = target.druidMetric;
         var dimension = templateSrv.replace(target.dimension);
-        promise = this._topNQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, threshold, metric, dimension)
+        promise = this._topNQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, threshold, metric, dimension, scopedVars)
           .then(function(response) {
             return convertTopNData(response.data, dimension, metric);
           });
       }
       else if (target.queryType === 'groupBy') {
         limitSpec = getLimitSpec(target.limit, target.orderBy);
-        promise = this._groupByQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, groupBy, limitSpec)
+        promise = this._groupByQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, groupBy, limitSpec, scopedVars)
           .then(function(response) {
             return convertGroupByData(response.data, groupBy, metricNames);
           });
       }
       else if (target.queryType === 'select') {
-        promise = this._selectQuery(datasource, intervals, granularity, selectDimensions, selectMetrics, filters, selectThreshold);
+        promise = this._selectQuery(datasource, intervals, granularity, selectDimensions, selectMetrics, filters, selectThreshold, scopedVars);
         return promise.then(function(response) {
           return convertSelectData(response.data);
         });
       }
       else {
-        promise = this._timeSeriesQuery(datasource, intervals, granularity, filters, aggregators, postAggregators)
+        promise = this._timeSeriesQuery(datasource, intervals, granularity, filters, aggregators, postAggregators, scopedVars)
           .then(function(response) {
             return convertTimeSeriesData(response.data, metricNames);
           });
@@ -229,7 +229,7 @@ function (angular, _, dateMath, moment) {
       });
     };
 
-    this._selectQuery = function (datasource, intervals, granularity, dimension, metric, filters, selectThreshold) {
+    this._selectQuery = function (datasource, intervals, granularity, dimension, metric, filters, selectThreshold, scopedVars) {
       var query = {
         "queryType": "select",
         "dataSource": datasource,
@@ -241,13 +241,13 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
     };
 
-    this._timeSeriesQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators) {
+    this._timeSeriesQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators, scopedVars) {
       var query = {
         "queryType": "timeseries",
         "dataSource": datasource,
@@ -258,14 +258,14 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
     };
 
     this._topNQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators,
-    threshold, metric, dimension) {
+    threshold, metric, dimension, scopedVars) {
       var query = {
         "queryType": "topN",
         "dataSource": datasource,
@@ -280,14 +280,14 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
     };
 
     this._groupByQuery = function (datasource, intervals, granularity, filters, aggregators, postAggregators,
-    groupBy, limitSpec) {
+    groupBy, limitSpec, scopedVars) {
       var query = {
         "queryType": "groupBy",
         "dataSource": datasource,
@@ -300,7 +300,7 @@ function (angular, _, dateMath, moment) {
       };
 
       if (filters && filters.length > 0) {
-        query.filter = buildFilterTree(filters);
+        query.filter = buildFilterTree(filters, scopedVars);
       }
 
       return this._druidQuery(query);
@@ -327,10 +327,10 @@ function (angular, _, dateMath, moment) {
       };
     }
 
-    function buildFilterTree(filters) {
+    function buildFilterTree(filters, scopedVars) {
       //Do template variable replacement
       var replacedFilters = filters.map(function (filter) {
-        return filterTemplateExpanders[filter.type](filter);
+        return filterTemplateExpanders[filter.type](filter, scopedVars);
       })
       .map(function (filter) {
         var finalFilter = _.omit(filter, 'negate');


### PR DESCRIPTION
When using grafana repeat panel option with template variable with All or multiple select options, filtering for each panel didn't work earlier. This commit is a workaround to this problem.

<img width="591" alt="screenshot 2018-08-07 23 51 38" src="https://user-images.githubusercontent.com/5604510/43793910-a98e0cd4-9a9e-11e8-8fa9-aef488753f1b.png">

<img width="879" alt="screenshot 2018-08-07 23 51 11" src="https://user-images.githubusercontent.com/5604510/43793909-a956021c-9a9e-11e8-87fa-3559752b51eb.png">

<img width="1274" alt="screenshot 2018-08-07 23 49 49" src="https://user-images.githubusercontent.com/5604510/43793905-a8dc75fa-9a9e-11e8-8c72-845adde3477f.png">

<img width="1269" alt="screenshot 2018-08-07 23 50 11" src="https://user-images.githubusercontent.com/5604510/43794145-3d9747a6-9a9f-11e8-9484-3e944906ff09.png">
